### PR TITLE
use recommended way of getting the version number

### DIFF
--- a/memprof/__init__.py
+++ b/memprof/__init__.py
@@ -17,4 +17,4 @@
 from .memprof import *
 import pkg_resources
 
-__version__ = pkg_resources.require("memprof")[0].version
+__version__ = pkg_resources.get_distribution("memprof").version


### PR DESCRIPTION
pkg_resources.require() should not be called directly, it raises
DistributionNotFound() for tornado and nose in Debian (and probably
others).  get_distribution() gives you the version as well and is not
recommended against in the documentation, so use it.
