### PR TITLE
Don't die with python 3.4 if memprof is not yet installed

### DIFF
--- a/memprof/__init__.py
+++ b/memprof/__init__.py
@@ -17,4 +17,7 @@
 from .memprof import *
 import pkg_resources
 
-__version__ = pkg_resources.get_distribution("memprof").version
+try:
+    __version__ = pkg_resources.get_distribution("memprof").version
+except pkg_resources.DistributionNotFound:
+    __version__ = "local"


### PR DESCRIPTION
pkg_resources changed behaviour in python 3.4 and now raises
DistributionNotFound if the package you're building is not yet
installed.  When running the testsuite we import memprof in the current
directory.  However pkg_resources is unable to find it and we fail to
get the current version of memprof.  Set it to local in order to be able
to run the testsuite before installing the package.