### PR TITLE
Update setup.py

### DIFF
--- a/memprof/memprof.py
+++ b/memprof/memprof.py
@@ -39,7 +39,7 @@ def memprof(*args, **kwargs):
 
 
 class MemProf(object):
-    def __init__(self, func, threshold=default_threshold, plot=False):
+    def __init__(self, func, threshold=default_threshold, plot=False, path_prefix=''):
         self.func = func
         self.__locals = {}
         self.__start = -1
@@ -48,7 +48,7 @@ class MemProf(object):
         self.__refresh = 500000
         self.__ticks = 0
         self.__checkTimes = []
-        self.__logfile = "%s.log" % self.func.__name__
+        self.__logfile = f'{path_prefix}{self.func.__name__}.log'
 
         self.__plot = self.func.__globals__["memprof_plot"] if "memprof_plot" in self.func.__globals__ else plot
         self.threshold = self.func.__globals__["memprof_threshold"] if "memprof_threshold" in self.func.__globals__ else threshold

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,10 @@ from setuptools.command.easy_install import easy_install
 try:
     from Cython.Distutils import build_ext
 except ImportError:
-    from setuptools.command import easy_install  # noqa
+    from setuptools.command import easy_install as easy_install_module  # noqa
     import pkg_resources
     # Install cython
-    easy_install.main(["Cython"])
+    easy_install_module.main(["Cython"])
     pkg_resources.require("Cython")
     from Cython.Distutils import build_ext
 


### PR DESCRIPTION
easy_install is module rather than class in catch. Fixed now.

In fact, if the code arrives at catch section, it overrides easy_install "class" with "module" variable. Thus, in line 42 of setup.py, it cannot inherit from module, thereby producing this error:

Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-8wnh7m_q/memprof/setup.py", line 40, in <module>
        class md_easy_install(easy_install):
    TypeError: module.__init__() takes at most 2 arguments (3 given)

