### PR TITLE
MNT: add pyproject.toml to fix compatibility with modern pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+  "setuptools>=19.6",
+  "wheel>=0.36.2",
+  "Cython>=0.26.1,<3.0"
+]


### PR DESCRIPTION
found that I was unable to install memprof from PyPI or github via pip + Python 3.9
Specifying build-time dependencies with pyproject.toml fixes it